### PR TITLE
Removed content of .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-*
-!target/*-runner
-!target/*-runner.jar
-!target/lib/*


### PR DESCRIPTION
.dockerignore file as it filters everything except the target directory and as we plan to build inside a container we need to be able to copy the src directory.