### PR TITLE
Add task to patch frontend configmap with backend URL

### DIFF
--- a/pipelines/01-pipelineresources/03-openshift-client-shell.yaml
+++ b/pipelines/01-pipelineresources/03-openshift-client-shell.yaml
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: openshift-client-shell
+spec:
+  inputs:
+    params:
+      - name: ARGS
+        description: The OpenShift CLI arguments to run
+        type: array
+        default:
+        - "help"
+  steps:
+    - name: oc
+      image: quay.io/openshift/origin-cli:latest
+      command: ["/bin/sh", "-c"]
+      args:
+        - "$(inputs.params.ARGS)"

--- a/pipelines/02-pipelines/01-findmyrelative-backend-pipeline.yaml
+++ b/pipelines/02-pipelines/01-findmyrelative-backend-pipeline.yaml
@@ -35,3 +35,13 @@ spec:
           - apply
           - -f
           - https://raw.githubusercontent.com/Emergency-Response-Demo/find-service/master/k8s/service.yaml
+  - name: patch-configmap
+    taskRef:
+      name: openshift-client-shell
+      kind: Task
+    runAfter:
+      - deploy
+    params:
+      - name: ARGS
+        value:
+          - oc patch configmap frontend-env -p '{"data": {"REACT_APP_BACKEND_URL": "$( oc get rt backend -o jsonpath={.status.url} )}}';


### PR DESCRIPTION
Add a task `patch-configmap` to pipeline which patches the `frontend-env` configmap with the updated `find-service` route.